### PR TITLE
Improved browser detection and handled CSP rule for Firefox

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,10 +17,13 @@
     },
     "permissions": [
         "tabs",
-        "storage"
+        "storage",
+        "declarativeNetRequest",
+        "browsingData"
     ],
     "host_permissions": [
-        "https://developer.apple.com/*"
+        "https://developer.apple.com/*",
+        "*://developer.apple.com/*"
     ],
     "content_scripts": [
         {

--- a/popup.css
+++ b/popup.css
@@ -10,7 +10,7 @@
 .popup {
     background-color: #FFFFFF;
     width: 280px;
-    padding: 0px;
+    padding: 0;
 }
 
 header {
@@ -19,7 +19,7 @@ header {
     height: 64px;
     display: flex;
     align-items: center;
-    padding: 0px 20px;
+    padding: 0 20px;
     font-size: 16px;
     font-weight: 600;
     box-sizing: border-box;


### PR DESCRIPTION
This commit comes with several changes directed towards Firefox browser. Firstly, the browser detection function has been updated to more accurately target Firefox. In earlier version, it was only checking the existence of the `browser` object which was not solely unique to Firefox. The update makes it to asynchronously obtain the browser information and compare it with known names.

In addition to that, a new functionality has been introduced in order to disable Content Security Policy (CSP) when the extension is running on Firefox. It operates by adding a new rule to modify specific response headers.

There are also changes noted in `manifest.json` permissions to allow 'declarativeNetRequest' and 'browsingData' for handling this new CSP rule.

Minor changes noted in CSS are done for consistency, replacing 'px' unit with its equivalent number value.

Fix: #11